### PR TITLE
Add default arg to taxonomy_menu_handler to avoid too few args fatal …

### DIFF
--- a/taxonomy_menu.module
+++ b/taxonomy_menu.module
@@ -563,7 +563,7 @@ function _taxonomy_menu_update_all_parents($term, $menu_name) {
  * @return array
  *   Menu link ID for the taxonomy menu item.
  */
-function taxonomy_menu_handler($op, $args, $node, $item = array()) {
+function taxonomy_menu_handler($op, $args, $node = NULL, $item = array()) {
 
   // Get the initial $item.
   if (empty($item)) {


### PR DESCRIPTION
Proposed fix for issue #11 that's working on my local. The $node arg seems unnecessary in these cases; several calls are made to taxonomy_menu_handler throughout the code without providing the $node arg, resulting in an error.